### PR TITLE
add docs for service catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ tasks.py
   labeler.yml
   labels.yml
   workflows/
-    ci.yml (only adding part)
+    ci.yml ## only adding part
     sync-docs.yml
 ```
 
@@ -63,22 +63,25 @@ tasks.py
 docs/
   docusaurus.config.ts
   sidebars.ts
-  docs/<projectname>  <— Put docs here
+  docs/  ## Put docs here
 .github/
   workflows/
-    ci.yml (only adding part)
-    sync-docs.yml (paths)
+    ci.yml ## only adding part
+    sync-docs.yml ## paths
 ```
 
 - `chmod 755 .github/build-docs.sh`
 
-- In `infrahub-docs`:
+### In `infrahub-docs` modify the following
 
 ```console
-docs/sidebars-<projectname>.ts
-docs/docs-<projectname>/<projectname>/readme.mdx <-- Placeholder
-docs/docusaurus.config.ts <-- Add a plugin and navbar entry
+touch docs/sidebars-<projectname>.ts
+mkdir docs/docs-<projectname>
+touch docs/docs-<projectname>/readme.mdx ### Placeholder
+vi docs/docusaurus.config.ts ### Add a plugin and navbar entry
 ```
+
+### Remaining tasks
 
 - Setup Cloudflare Pages Integration
 - Create PRs and test

--- a/docs/docs-service-catalog/readme.mdx
+++ b/docs/docs-service-catalog/readme.mdx
@@ -1,0 +1,77 @@
+---
+title: PoC for Service Catalog
+---
+
+import CodeBlock from '@theme/CodeBlock';
+
+This repository is a proof of concept for service catalog using Infrahub and Streamlit.
+
+## Running the demo
+
+### Clone the repository
+
+Clone the GitHub repository to the server you will run this demo on:
+
+```shell
+git clone https://github.com/opsmill/poc-service-catalog.git
+cd poc-service-catalog
+```
+
+### Prerequisites
+
+Before you get started, make sure the following tools are installed:
+
+- ✅ **Infrahub Docker Compose Requirements**
+  Follow the [Infrahub installation guide](https://docs.infrahub.app/guides/installation#docker-compose) to set up the necessary Docker Compose environment.
+
+- 🐍 **Poetry**
+  Install Poetry by following the [official installation guide](https://python-poetry.org/docs).
+
+- 🧪 **Containerlab (For Lab Testing)**
+  If you plan to run lab topologies, you'll also need [Containerlab](https://containerlab.dev/install/).
+
+### Set environmental variables
+
+```shell
+export INFRAHUB_ADDRESS="http://localhost:8000"
+export INFRAHUB_API_TOKEN="06438eb2-8019-4776-878c-0941b1f1d1ec"
+```
+
+### Install the Infrahub SDK
+
+Our demos use [poetry](https://python-poetry.org/) to manage the Python environment.
+
+```shell
+poetry install
+```
+
+### Start Infrahub
+
+```shell
+poetry run invoke start
+```
+
+### Load schema and data into Infrahub
+
+```shell
+infrahubctl schema load schemas/
+infrahubctl object load data/
+```
+
+### Connect read-only repository
+
+```shell
+infrahubctl repository add --ref main --read-only infrahub-demo https://github.com/opsmill/poc-service-catalog.git
+```
+
+### Spin service catalog app
+
+```shell
+streamlit run service_catalog/🏠_Home_Page.py`
+```
+
+### Login
+
+👉 Login to [Infrahub UI](http://localhost:8000/login) on port `8000` with username `admin` and password `infrahub`
+
+👉 You can connect to [Service catalog](http://localhost:8501/) on port `8501`

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -174,6 +174,16 @@ const config: Config = {
         sidebarPath: './sidebars-infrahubctl.ts',
       },
     ],
+    [
+      '@docusaurus/plugin-content-docs',
+      {
+        id: 'docs-service-catalog',
+        path: 'docs-service-catalog',
+        routeBasePath: 'service-catalog',
+        sidebarCollapsed: false,
+        sidebarPath: './sidebars-service-catalog.ts',
+      },
+    ],
   ],
   themes: [
     [
@@ -259,6 +269,12 @@ const config: Config = {
               sidebarId: "demoSidebar",
               label: "demo-dc-fabric",
               docsPluginId: "docs-demo",
+            },
+            {
+              type: "docSidebar",
+              sidebarId: "servicecatalogSidebar",
+              label: "poc-service-catalog",
+              docsPluginId: "docs-service-catalog",
             },
             {
               type: "docSidebar",

--- a/docs/sidebars-service-catalog.ts
+++ b/docs/sidebars-service-catalog.ts
@@ -1,0 +1,9 @@
+import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
+
+const sidebars: SidebarsConfig = {
+  servicecatalogSidebar: [
+    'readme',
+  ]
+};
+
+export default sidebars;


### PR DESCRIPTION
Moved docs for `poc-service-catalog` from it's readme to the docs repo