### PR TITLE
Add Google Analytics 4 to the documentation site

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -69,6 +69,10 @@ const config: Config = {
         theme: {
           customCss: "./src/css/custom.css",
         },
+        gtag: {
+          trackingID: process.env.GA_MEASUREMENT_ID ?? "G-12QVSPMRGD",
+          anonymizeIP: true,
+        },
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
## Summary

Adds Google Analytics 4 tracking to the Infrahub documentation site using the `gtag` option built into `@docusaurus/preset-classic`. No new dependencies required.

The Measurement ID (`G-12QVSPMRGD`) is baked in as a default so the production deployment works out of the box, but can be overridden at build time via the `GA_MEASUREMENT_ID` environment variable — useful for pointing preview/staging deploys at a separate GA property later.

`anonymizeIP` is enabled for GDPR posture.

## Test plan

- [x] `npm run build` succeeds locally
- [x] Built HTML contains the gtag snippet and the `G-12QVSPMRGD` tracking ID
- [ ] After merge + Cloudflare Pages deploys, verify hits appear in GA4 → Reports → Realtime when visiting https://docs.infrahub.app

## Notes

- Runs alongside the existing Plausible integration — no conflict.
- To exclude internal/dev traffic from GA reports, configure an Internal Traffic filter in GA4 (Admin → Data Streams → Configure tag settings → Define internal traffic).