### PR TITLE
Fix Google Analytics measurement ID

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -70,7 +70,7 @@ const config: Config = {
           customCss: "./src/css/custom.css",
         },
         gtag: {
-          trackingID: process.env.GA_MEASUREMENT_ID ?? "G-12QVSPMRGD",
+          trackingID: process.env.GA_MEASUREMENT_ID ?? "G-FNVRQ6HH0B",
           anonymizeIP: true,
         },
       } satisfies Preset.Options,


### PR DESCRIPTION
## Summary

Updates the default Google Analytics 4 measurement ID in `docs/docusaurus.config.ts` from `G-12QVSPMRGD` to `G-FNVRQ6HH0B`.

The previous value was incorrect and not associated with the intended analytics property, so pageview data was not being captured in the right place.

## Test plan

- [x] Verified the change is isolated to the `gtag.trackingID` fallback value
- [x] The `GA_MEASUREMENT_ID` environment variable still overrides the default when set
- [ ] After merge, confirm events arrive in the GA4 property for `G-FNVRQ6HH0B`