### PR TITLE
Fix demo-dc navbar sidebarId after upstream rename

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -418,7 +418,7 @@ const config: Config = {
           items: [
             {
               type: "docSidebar",
-              sidebarId: "BundleDcSidebar",
+              sidebarId: "DemoDcSidebar",
               label: "DC Bundle",
               docsPluginId: "docs-demo-dc",
             },


### PR DESCRIPTION
## Summary

- Update `docs/docusaurus.config.ts` navbar entry from `sidebarId: "BundleDcSidebar"` to `sidebarId: "DemoDcSidebar"` to match the upstream-synced sidebar export.
- Restores `npm run build` (CI run [25051441600](https://github.com/opsmill/infrahub-docs/actions/runs/25051441600/job/73379986149) failed SSG for every `/demo-dc/*` route with `Can't find any sidebar with id "BundleDcSidebar"`).

## Root cause

PR #147 (`Rename bundle-dc docs section to demo-dc`) renamed paths but left both the sidebar export *and* the navbar reference on the legacy `BundleDc` name, so the build stayed green. Today's automated `Sync docs from infrahub-demo-dc repo` commit (`4fb4841`) finally renamed the export to `DemoDcSidebar`, exposing the stale navbar id in `docusaurus.config.ts`.

## Test plan

- [x] `npm run build` in `docs/` succeeds locally
- [ ] CI build job passes on this PR