### PR TITLE
Rename DC Bundle navbar label to demo-dc

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -427,7 +427,7 @@ const config: Config = {
             {
               type: "docSidebar",
               sidebarId: "DemoDcSidebar",
-              label: "DC Bundle",
+              label: "demo-dc",
               docsPluginId: "docs-demo-dc",
             },
             {


### PR DESCRIPTION
Renames the navbar dropdown item under **Demos & Examples** from `DC Bundle` to `demo-dc` in `docs/docusaurus.config.ts`, aligning the display label with the route/plugin ID (`docs-demo-dc`).