### PR TITLE
docs: name OpsMill in llms.txt site title and description

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -297,8 +297,8 @@ const config: Config = {
     [
       '@signalwire/docusaurus-plugin-llms-txt',
       {
-        siteTitle: 'Infrahub Documentation',
-        siteDescription: 'Comprehensive guide to Infrahub - the modern infrastructure management platform',
+        siteTitle: 'Infrahub by OpsMill - Documentation',
+        siteDescription: 'Infrahub by OpsMill - the modern infrastructure data management platform. Infrahub is the open-source product built by OpsMill (https://opsmill.com).',
         depth: 2,
         content: {
           enableMarkdownFiles: true,


### PR DESCRIPTION
## Why

The `llms.txt` file served at https://docs.infrahub.app/llms.txt is consumed by AI assistants and LLM crawlers to learn what this site is about. It is generated by the `@signalwire/docusaurus-plugin-llms-txt` plugin from the `siteTitle` / `siteDescription` set in `docs/docusaurus.config.ts`.

Today its header reads:

> Comprehensive guide to Infrahub - the modern infrastructure management platform

It **never mentions OpsMill**, so an LLM reading this file gets no signal that Infrahub is the open-source product built by OpsMill. This is part of a broader effort to help search engines and LLM crawlers associate `docs.infrahub.app` with `opsmill.com` (the company site), since the product and company have different names.

## Change

In the `@signalwire/docusaurus-plugin-llms-txt` plugin config:

- `siteTitle`: `Infrahub Documentation` → `Infrahub by OpsMill - Documentation`
- `siteDescription`: now names and links OpsMill —
  > Infrahub by OpsMill - the modern infrastructure data management platform. Infrahub is the open-source product built by OpsMill (https://opsmill.com).

These strings become the title and `> ` blockquote at the top of the generated `llms.txt` (and `llms-full.txt`).

## Related

Companion to the cross-linking changes in opsmill/infrahub#9470 (JSON-LD structured data, `og:site_name`, footer attribution, overview-page "built by OpsMill" + Solutions list).

A separate, still-open follow-up is on the **opsmill.com** side: add bidirectional JSON-LD (include docs.infrahub.app + the GitHub org in the Organization `sameAs`, and add an Infrahub `SoftwareApplication` node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)