### PR TITLE
fix(deps): bump http-proxy-middleware to 3.0.7 (alert #102)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -11546,9 +11546,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.6.tgz",
-      "integrity": "sha512-jhO3QfahaHWfQjEnyGW0vpYIYaXcnA6FEfehrBthOokGppvmI6zcV+1yb6TWn3vyeh8yQUoEqH51DNHOCjivxg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.15",

--- a/docs/package.json
+++ b/docs/package.json
@@ -45,7 +45,7 @@
     "dompurify": "3.4.11",
     "fast-uri": "3.1.2",
     "follow-redirects": "1.16.0",
-    "http-proxy-middleware": "3.0.6",
+    "http-proxy-middleware": "3.0.7",
     "joi": "17.13.4",
     "js-yaml@^4.0.0": "4.2.0",
     "launch-editor": "2.14.1",


### PR DESCRIPTION
## Description

Follow-up to #170. After that PR bumped `http-proxy-middleware` to `3.0.6`, a **newer high-severity advisory** appeared that covers `3.0.6`:

- **GHSA-gcq2-9pq2-cxqm** (high) — multipart/form-data field injection via unescaped CRLF in `fixRequestBody`, vulnerable range `>= 3.0.4, < 3.0.7`, fixed in **3.0.7**.

This bumps the `http-proxy-middleware` override to `3.0.7`. Cross-checked against every published `http-proxy-middleware` advisory — `3.0.7` is outside all of them, so this fully clears the package (Dependabot alert **#102**).

`http-proxy-middleware` is a transitive dev-only dependency of `webpack-dev-server` (`npm start`); no dev-server proxy is configured, so it is not exercised at build or runtime.

## Type of change

- [x] Website build/deployment configuration
- [x] Bug fix (website technical issue)

## Testing

- [x] Tested local build with `npm run build` — passes clean (0 errors)
- [x] Verified `3.0.7` resolves in `package-lock.json` and is outside every vulnerable range

## Checklist

- [x] I have confirmed this PR is for website infrastructure, not documentation content
- [x] I have tested the changes locally
- [x] The build passes without errors
- [x] I have updated documentation if needed (n/a — dependency change only)
