### PR TITLE
fix(docs): register release-notes-data plugin

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -78,6 +78,8 @@ const config: Config = {
     ],
   ],
   plugins: [
+    // Scans release-notes frontmatter into global data for <ReleaseFeed/>.
+    './plugins/release-notes-data',
     [
       '@docusaurus/plugin-client-redirects',
       {


### PR DESCRIPTION
## Problem

The Cloudflare build fails at sidebar loading:

```
[ERROR] Sidebars file at ".../docs/sidebars.ts" failed to be loaded.
[cause]: Error: Cannot find module './sidebar-releases'
```

The synced `sidebars.ts` and `release-notes/infrahub/index.mdx` depend on the release-notes redesign support files from `opsmill/infrahub` — `sidebar-releases.ts`, the `ReleaseFeed` component, and the `release-notes-data` plugin. The docs sync never copied them here; that is fixed upstream in **opsmill/infrahub#9986**.

## Change

Register the `release-notes-data` plugin in `docusaurus.config.ts`. This is the one piece that **cannot** be synced from upstream — this repo's config is hand-maintained — so it lives here. `<ReleaseFeed/>` reads that plugin's global data via `usePluginData("release-notes-data")`.

## ⚠️ Merge sequencing

This PR and the sync fix must land together, or the build breaks in the interim:

1. Merge **opsmill/infrahub#9986** → trigger the `Sync Folders` workflow (it has `workflow_dispatch`) so it delivers `sidebar-releases.ts`, `docs/plugins/`, and `docs/src/components/ReleaseFeed/` here.
2. Then merge this PR.

If this merges before the files arrive, the build fails (plugin path missing). If the files arrive before this merges, `<ReleaseFeed/>` crashes (no plugin data).

## Testing

Built locally with the upstream support files present + this registration: build succeeds (`Generated static files`, 629 docs) and `<ReleaseFeed/>` renders at `/release-notes/infrahub`.